### PR TITLE
Campo Attachment obbligatorio ma può essere vuoto

### DIFF
--- a/src/Enums/DocumentType.php
+++ b/src/Enums/DocumentType.php
@@ -24,6 +24,7 @@ namespace FatturaElettronicaPhp\FatturaElettronica\Enums;
  * @method static self TD25()
  * @method static self TD26()
  * @method static self TD27()
+ * @method static self TD28()
  */
 class DocumentType extends Enum
 {

--- a/src/Writer/Body/AttachmentWriter.php
+++ b/src/Writer/Body/AttachmentWriter.php
@@ -21,7 +21,13 @@ class AttachmentWriter extends AbstractBodyWriter
                 throw new InvalidDocument('<NomeAttachment> is required');
             }
 
-            if (! $attachment->getFileData()) {
+            /* if (! $attachment->getFileData()) { */
+            /*
+            fix: da specifiche il campo Attachment è obbligatorio che sia presente, ma la sua dimensione
+            può essere nulla (le specifiche parlano solo di dim. max): in caso di allegato vuoto si avrà un tag selfclosed <Attachment/> valido
+            ad esempio Aruba accetta il transito di questo tipo di casistiche
+            */
+            if (! property_exists($attachment, "attachment") ) {
                 throw new InvalidDocument('<Attachment> is required');
             }
 


### PR DESCRIPTION
come da specifice tecniche e confermato da Aruba