### PR TITLE
Fix *CustomerWriter check vatNumber

### DIFF
--- a/src/Writer/Header/CustomerWriter.php
+++ b/src/Writer/Header/CustomerWriter.php
@@ -21,7 +21,7 @@ class CustomerWriter extends AbstractHeaderWriter
 
         $fiscalData = $this->calculateFiscalData($idPaese, $codiceFiscale, $vatNumber);
 
-        if (! empty($vatNumber)) {
+        if (! empty($fiscalData['idCodice'])) {
             $idFiscaleIva = $datiAnagrafici->addChild('IdFiscaleIVA');
             $idFiscaleIva->addChild('IdPaese', $idPaese);
             $idFiscaleIva->addChild('IdCodice', SimpleXmlExtended::sanitizeText($fiscalData['idCodice']));

--- a/src/Writer/Header/SimplifiedCustomerWriter.php
+++ b/src/Writer/Header/SimplifiedCustomerWriter.php
@@ -21,7 +21,7 @@ class SimplifiedCustomerWriter extends AbstractHeaderWriter
 
         $fiscalData = $this->calculateFiscalData($idPaese, $codiceFiscale, $vatNumber);
 
-        if (! empty($vatNumber)) {
+        if (! empty($fiscalData['idCodice'])) {
             $idFiscaleIva = $identificativiFiscali->addChild('IdFiscaleIVA');
             $idFiscaleIva->addChild('IdPaese', $idPaese);
             $idFiscaleIva->addChild('IdCodice', SimpleXmlExtended::sanitizeText($fiscalData['idCodice']));


### PR DESCRIPTION
When idPaese !== 'IT' FiscalData idCodice can be filled with codiceFiscale via calculateFiscalData, and must be added in the document as IdFiscaleIVA->IdCodice