### PR TITLE
Get a properly formatted xml file on write from .p7m files

### DIFF
--- a/src/Writer/DigitalDocumentWriter.php
+++ b/src/Writer/DigitalDocumentWriter.php
@@ -57,14 +57,14 @@ class DigitalDocumentWriter implements DigitalDocumentWriterInterface
             $filePath = $filePath . '/' . $this->document->generatedFilename();
         }
 
-        if ($format) {
+       // if ($format) {
             /** @var DOMDocument $dom */
             $dom = dom_import_simplexml($this->generate()->xml())->ownerDocument;
             $dom->preserveWhiteSpace = false;
             $dom->formatOutput = true;
 
             return $dom->save($filePath);
-        }
+       // }
 
         return $this->generate()->xml()->asXML($filePath);
     }


### PR DESCRIPTION
The xml file loses formatting on save from **.p7m files**.
Removing the **if statemenet** in the `public function write($filePath, bool $format = false):bool{...}` seems to solve the problem. Removing the **if statemenet** doesn't seems to affect other xml files.

```
       //if ($format) {
            /** @var DOMDocument $dom */
            $dom = dom_import_simplexml($this->generate()->xml())->ownerDocument;
            $dom->preserveWhiteSpace = false;
            $dom->formatOutput = true;

            return $dom->save($filePath);
        //}
```

