### PR TITLE
Fixed unwanted single quote during error parsing

### DIFF
--- a/src/Validator/DigitalDocumentValidator.php
+++ b/src/Validator/DigitalDocumentValidator.php
@@ -88,7 +88,7 @@ class DigitalDocumentValidator
         $field = '';
         if (stripos($message, "Element ") === 0) {
             $message = substr($message, strlen("Element "));
-            $field = substr($message, 1, stripos($message, ':') - 1);
+            $field = substr($message, 1, stripos($message, ':') - 2);
             $message = substr($message, stripos($message, ':') + 2);
         }
 


### PR DESCRIPTION
I noticed that the keys of the array obtained after validation contain an unwanted single quote

```
{
    "IdPaese'": "[facet 'pattern'] The value '' is not accepted by the pattern '[A-Z]{2}'.\n",
    "IdCodice'": "[facet 'minLength'] The value has a length of '0'; this underruns the allowed minimum length of '1'.\n"
}
```