### PR TITLE
Update CMSDecoder.php

### DIFF
--- a/src/Decoder/CMSDecoder.php
+++ b/src/Decoder/CMSDecoder.php
@@ -20,6 +20,10 @@ class CMSDecoder implements DigitalDocumentDecodeInterface
             openssl_cms_verify($p7mFilePath, OPENSSL_CMS_NOVERIFY + OPENSSL_CMS_NOSIGS, $pemPath, [__DIR__ . '/ca.pem'], __DIR__ . '/ca.pem', $xmlPath)
         ) {
             return (new XMLDecoder())->decode($xmlPath);
+            
+            //remove created temporery files from directory
+            $tempdir =  sys_get_temp_dir();
+            array_map('unlink', array_filter((array) glob($tempdir ."/*.p7m*")));
         }
 
         $exitCode = 0;


### PR DESCRIPTION
Removes temporary files created in the default /tmp directory to avoid wasting space in the long run. The “*.p7m*” pattern removes only .p7mxxxxx files created in the directory (xxxxx are casual numbers)