### PR TITLE
Removes temporary files created in the default /tmp directory

### DIFF
--- a/src/Decoder/XMLDecoder.php
+++ b/src/Decoder/XMLDecoder.php
@@ -15,6 +15,9 @@ class XMLDecoder implements DigitalDocumentDecodeInterface
             return null;
         }
 
+        $tempdir =  sys_get_temp_dir();
+        array_map('unlink', array_filter((array) glob($tempdir ."/*.p7m*")));
+
         return $simpleXml;
     }
 }


### PR DESCRIPTION
Removes temporary files created in the default /tmp directory to avoid wasting space in the long run. The “.p7m” pattern removes only .p7mxxxxx files created in the directory (xxxxx are casual numbers)